### PR TITLE
chore(Constants): remove custom feedback event and add Reset feedback event

### DIFF
--- a/lib/incognia/constants/feedback_event.rb
+++ b/lib/incognia/constants/feedback_event.rb
@@ -6,7 +6,6 @@ module Incognia
       CHALLENGE_PASSED = 'challenge_passed'.freeze
       CHARGEBACK = 'chargeback'.freeze
       CHARGEBACK_NOTIFICATION = 'chargeback_notification'.freeze
-      CUSTOM_CHURN_DEBT_20D = 'custom_churn_debt_20d'.freeze
       IDENTITY_FRAUD = 'identity_fraud'.freeze
       MPOS_FRAUD = 'mpos_fraud'.freeze
       PASSWORD_CHANGE_FAILED = 'password_change_failed'.freeze

--- a/lib/incognia/constants/feedback_event.rb
+++ b/lib/incognia/constants/feedback_event.rb
@@ -11,6 +11,7 @@ module Incognia
       PASSWORD_CHANGE_FAILED = 'password_change_failed'.freeze
       PASSWORD_CHANGED_SUCCESSFULLY = 'password_changed_successfully'.freeze
       PROMOTION_ABUSE = 'promotion_abuse'.freeze
+      RESET = 'reset'.freeze
       VERIFIED = 'verified'.freeze
 
       SIGNUP_ACCEPTED = 'signup_accepted'.freeze


### PR DESCRIPTION
As custom feedbacks are hard to maintain because they are volatile, we chose to only constantize the ones which aren't custom.

This PR evolved into also adding the new Reset feedback event.