### PR TITLE
fix(client): generate json from received data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ gem "rspec", "~> 3.0"
 group :test do
   gem "webmock"
   gem "timecop"
+  gem "pry"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    incognia_api (0.4.0)
+    incognia_api (0.4.1)
       faraday
       faraday_middleware
 
@@ -10,6 +10,7 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    coderay (1.1.3)
     crack (0.4.5)
       rexml
     diff-lcs (1.4.4)
@@ -39,7 +40,11 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     hashdiff (1.0.1)
+    method_source (1.0.0)
     multipart-post (2.3.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.6)
     rake (13.0.3)
     rexml (3.2.5)
@@ -69,6 +74,7 @@ PLATFORMS
 
 DEPENDENCIES
   incognia_api!
+  pry
   rake (~> 13.0)
   rspec (~> 3.0)
   timecop

--- a/lib/incognia_api/client.rb
+++ b/lib/incognia_api/client.rb
@@ -15,16 +15,18 @@ module Incognia
       @host = host
 
       @connection = Faraday.new(host) do |faraday|
-        faraday.adapter Faraday.default_adapter
         faraday.request :json
         faraday.response :json, content_type: /\bjson$/
-        # faraday.response :logger, nil, { headers: true, bodies: true }
         faraday.response :raise_error
+
+        faraday.adapter Faraday.default_adapter
       end
     end
 
     def request(method, endpoint = nil, data = nil, headers = {})
-      connection.send(method, endpoint, data, headers) do |r|
+      json_data = JSON.generate(data) if data
+
+      connection.send(method, endpoint, json_data, headers) do |r|
         r.headers[Faraday::Request::Authorization::KEY] ||= Faraday::Request
           .lookup_middleware(:authorization)
           .header(:Bearer, credentials.access_token)

--- a/lib/incognia_api/version.rb
+++ b/lib/incognia_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Incognia
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require "incognia_api"
 require "helpers/api_spec_helpers"
 require "webmock/rspec"
 require "timecop"
+require "pry"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Old versions of faraday or faraday_middleware may raise error if didn't convert the received data to json.

Taking into consideration that faraday and faraday_middleware versions were not specified it's necessary to be more defensive.