### PR TITLE
Fix/api resource

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    incognia_api (0.5.2)
+    incognia_api (0.5.3)
       faraday (~> 1.10)
       faraday_middleware (~> 1.2)
 

--- a/lib/incognia_api/resources/api_resource.rb
+++ b/lib/incognia_api/resources/api_resource.rb
@@ -1,13 +1,13 @@
 require 'delegate'
 
 module Incognia
-  class APIResource < SimpleDelegator
+  class APIResource < OpenStruct
     def self.from_hash(hash)
       hash = hash.each_with_object({}) do |(k, v), h|
         h[k] = v.is_a?(Hash) ? from_hash(v) : v
       end
 
-      new(OpenStruct.new(hash))
+      new(hash)
     end
   end
 end

--- a/lib/incognia_api/version.rb
+++ b/lib/incognia_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Incognia
-  VERSION = "0.5.2"
+  VERSION = "0.5.3"
 end

--- a/spec/resources/api_resource_spec.rb
+++ b/spec/resources/api_resource_spec.rb
@@ -3,18 +3,24 @@ require "spec_helper"
 module Incognia
   RSpec.describe APIResource do
     context ".from_hash" do
-      subject { described_class.from_hash(foo: { bar: :val }, list: [:one, :two]) }
+      subject(:from_hash) { described_class.from_hash(foo: { bar: :val }, list: [:one, :two]) }
 
       it "returns an instance of klass" do
-        expect(subject).to be_instance_of(described_class)
+        expect(from_hash).to be_instance_of(described_class)
       end
 
       it "builds a loose object from a hash" do
-        expect(subject.foo).to respond_to(:bar)
+        expect(from_hash.foo).to respond_to(:bar)
       end
 
       it "builds nested objects" do
-        expect(subject.foo.bar).to eql(:val)
+        expect(from_hash.foo.bar).to eql(:val)
+      end
+
+      context "when calling an inexistent attribute" do
+        it "returns nil" do
+          expect(from_hash.inexistent).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
Does not raise an error when calling an inexistent attribute from ApiResource.

Some API responses don't have device_id but the client doesn't know when this will occur and this can lead to an internal error.