### PR TITLE
Fix RFC3339 parcer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.5.5] - 2024-04-01
+
+- Fix datetime parcer to RFC3339 format
+
 ## [0.5.4] - 2024-03-19
 
 - Allow registering feedback with expires_at parameter 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    incognia_api (0.5.4)
+    incognia_api (0.5.5)
       faraday (~> 1.10)
       faraday_middleware (~> 1.2)
 

--- a/lib/incognia_api/api.rb
+++ b/lib/incognia_api/api.rb
@@ -57,7 +57,7 @@ module Incognia
 
     def register_feedback(event:, timestamp: nil, expires_at: nil, **ids)
       timestamp = timestamp.strftime('%s%L') if timestamp.respond_to? :strftime
-      expires_at = expires_at.strftime('%FT%TZ') if expires_at.respond_to? :strftime
+      expires_at = expires_at.to_datetime.rfc3339 if expires_at.respond_to? :to_datetime
 
       params = { event: event, timestamp: timestamp&.to_i, expires_at: expires_at }.compact
       params.merge!(ids)

--- a/lib/incognia_api/version.rb
+++ b/lib/incognia_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Incognia
-  VERSION = "0.5.4"
+  VERSION = "0.5.5"
 end

--- a/spec/incognia_spec.rb
+++ b/spec/incognia_spec.rb
@@ -437,7 +437,7 @@ module Incognia
 
           it "hits the endpoint with expires_at in RFC3339" do
             stub = stub_register_feedback_request.with(
-              body: { event: event, expires_at: expires_at.strftime('%FT%TZ') },
+              body: { event: event, expires_at: expires_at.to_datetime.rfc3339 },
               headers: {
                 'Content-Type' => 'application/json', 'Authorization' => /Bearer.*/
               }
@@ -454,7 +454,7 @@ module Incognia
 
           it "hits the endpoint with expires_at in RFC3339" do
             stub = stub_register_feedback_request.with(
-              body: { event: event, expires_at: expires_at.strftime('%FT%TZ') },
+              body: { event: event, expires_at: expires_at.to_datetime.rfc3339 },
               headers: {
                 'Content-Type' => 'application/json', 'Authorization' => /Bearer.*/
               }


### PR DESCRIPTION
This PR aims to fix the date parser for RFC3339 considering the timezone.
The current way:
```ruby
irb(main):003:0> Time.now.strftime('%FT%TZ')
=> "2024-04-01T13:56:47Z"

irb(main):004:0> DateTime.now.strftime('%FT%TZ')
=> "2024-04-01T13:57:07Z"
```
The new way:
```ruby
irb(main):001:0> Time.now.to_datetime.rfc3339
=> "2024-04-01T13:55:45-03:00"

irb(main):002:0> DateTime.now.to_datetime.rfc3339
=> "2024-04-01T13:56:01-03:00"
```


