### PR TITLE
feat: use occurred_at instead of timestamp in register_feedback requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.1.0] - 2024-07-24
+
+- Add support to passing request_token and occurred_at to #register_feedback
+
 ## [1.0.0] - 2024-07-05
 
 - Remove #get_signup_assessment, because the endpoint was discontinued

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    incognia_api (1.0.0)
+    incognia_api (1.1.0)
       faraday (~> 1.10)
       faraday_middleware (~> 1.2)
 

--- a/README.md
+++ b/README.md
@@ -202,12 +202,14 @@ The `expires_at` argument should be a _Time_, _DateTime_ or an date in **RFC 333
 
 
 ```ruby
-account_id = "cdb2cfbb-8ad8-4668-b276-5fff9bbfdc96"
-timestamp = DateTime.parse('2022-06-20 23:29:00 UTC-3')
+installation_id = 'installation-id'
+account_id = 'account-id'
+occurred_at = DateTime.parse('2024-07-22T15:20:00Z')
 
 success = api.register_feedback(
-  event: Incognia::Constants::FeedbackEvent::IDENTITY_FRAUD,
-  timestamp: timestamp,
+  event: Incognia::Constants::FeedbackEvent::ACCOUNT_TAKEOVER,
+  occurred_at: occurred_at,
+  installation_id: installation_id,
   account_id: account_id
 )
 
@@ -219,9 +221,9 @@ For custom fraud, set the value of `event` with the corresponding code:
 ```ruby
 success = api.register_feedback(
   event: 'custom_fraud_name',
-  timestamp: timestamp,
-  account_id: account_id,
-  installation_id: installation_id
+  occurred_at: occurred_at,
+  installation_id: installation_id,
+  account_id: account_id
 )
 
 # => true

--- a/lib/incognia_api/api.rb
+++ b/lib/incognia_api/api.rb
@@ -46,11 +46,16 @@ module Incognia
       LoginAssessment.from_hash(response.body) if response.success?
     end
 
-    def register_feedback(event:, timestamp: nil, expires_at: nil, **ids)
+    def register_feedback(event:, occurred_at: nil, expires_at: nil, timestamp: nil, **ids)
+      if !timestamp.nil?
+        warn("Deprecation warning: use occurred_at instead of timestamp")
+      end
+
       timestamp = timestamp.strftime('%s%L') if timestamp.respond_to? :strftime
+      occurred_at = occurred_at.to_datetime.rfc3339 if occurred_at.respond_to? :to_datetime
       expires_at = expires_at.to_datetime.rfc3339 if expires_at.respond_to? :to_datetime
 
-      params = { event: event, timestamp: timestamp&.to_i, expires_at: expires_at }.compact
+      params = { event: event, timestamp: timestamp&.to_i, occurred_at: occurred_at, expires_at: expires_at }.compact
       params.merge!(ids)
 
       response = connection.request(

--- a/lib/incognia_api/version.rb
+++ b/lib/incognia_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Incognia
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/spec/incognia_spec.rb
+++ b/spec/incognia_spec.rb
@@ -332,6 +332,14 @@ module Incognia
         expect(feedback_registered).to be(true)
       end
 
+      it "warns about the deprecation of timestamp" do
+        stub_register_feedback_request
+
+        expect(api).to receive(:warn).with("Deprecation warning: use occurred_at instead of timestamp")
+
+        api.register_feedback(event: event, timestamp: timestamp)
+      end
+
       context "HTTP request" do
         it "hits the endpoint with event, timestamp and expires_at" do
           stub = stub_register_feedback_request
@@ -391,6 +399,40 @@ module Incognia
             )
 
             api.register_feedback(event: event)
+
+            expect(stub).to have_been_made.once
+          end
+        end
+
+        context "when receiving occurred_at as a Time" do
+          let(:occurred_at) { Time.now }
+
+          it "hits the endpoint with expires_at in RFC3339" do
+            stub = stub_register_feedback_request.with(
+              body: { event: event, occurred_at: occurred_at.to_datetime.rfc3339 },
+              headers: {
+                'Content-Type' => 'application/json', 'Authorization' => /Bearer.*/
+              }
+            )
+
+            api.register_feedback(event: event, occurred_at: occurred_at)
+
+            expect(stub).to have_been_made.once
+          end
+        end
+
+        context "when receiving occurred_at as a DateTime" do
+          let(:occurred_at) { DateTime.now }
+
+          it "hits the endpoint with occurred_at in RFC3339" do
+            stub = stub_register_feedback_request.with(
+              body: { event: event, occurred_at: occurred_at.to_datetime.rfc3339 },
+              headers: {
+                'Content-Type' => 'application/json', 'Authorization' => /Bearer.*/
+              }
+            )
+
+            api.register_feedback(event: event, occurred_at: occurred_at)
 
             expect(stub).to have_been_made.once
           end


### PR DESCRIPTION
This commit also adds a test to validate whether the new request_token field is supported.