### PR TITLE
Feat/make account id optional on payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.3.0] - 2024-10-17
+
+- Updated the `register_payment` method to make `account_id` optional.
+
 ## [1.2.0] - 2024-08-26
 
 - Removes the requirement to send installation id to register signup, login and payment

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    incognia_api (1.2.0)
+    incognia_api (1.3.0)
       faraday (~> 1.10)
       faraday_middleware (~> 1.2)
 

--- a/lib/incognia_api/api.rb
+++ b/lib/incognia_api/api.rb
@@ -67,7 +67,7 @@ module Incognia
       response.success?
     end
 
-    def register_payment(account_id:, request_token: nil, **opts)
+    def register_payment(account_id: nil, request_token: nil, **opts)
       params = {
         type: :payment,
         account_id: account_id,

--- a/lib/incognia_api/version.rb
+++ b/lib/incognia_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Incognia
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/spec/incognia_spec.rb
+++ b/spec/incognia_spec.rb
@@ -303,6 +303,34 @@ module Incognia
         it_behaves_like 'receiving one of the required tokens with account_id', :installation_id
         it_behaves_like 'receiving one of the required tokens with account_id', :session_token
 
+        shared_examples_for 'receiving one of the required tokens without account_id' do |token_name|
+          let(:token_value) { SecureRandom.uuid }
+
+          it "hits the endpoint with #{token_name}" do
+            stub_token_request
+
+            stub = stub_payment_request.with(
+              body: {
+                type: 'payment',
+                token_name => token_value
+              },
+              headers: {
+                'Content-Type' => 'application/json', 'Authorization' => /Bearer.*/
+              }
+            )
+
+            api.register_payment(
+              token_name => token_value
+            )
+
+            expect(stub).to have_been_made.once
+          end
+        end
+
+        it_behaves_like 'receiving one of the required tokens without account_id', :request_token
+        it_behaves_like 'receiving one of the required tokens without account_id', :installation_id
+        it_behaves_like 'receiving one of the required tokens without account_id', :session_token
+
         context 'when receiving any other optional arguments' do
           shared_examples_for 'receiving optional args' do |optional_arguments|
             it "hits the endpoint also with #{optional_arguments}" do


### PR DESCRIPTION
Updated the `register_payment` method to make `account_id` optional.