### PR TITLE
Feat/api singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.3.0] - 2024-10-30
+
+- Add support for general configuration and use Incognia::Api as a static class
+
 ## [1.2.0] - 2024-08-26
 
 - Removes the requirement to send installation id to register signup, login and payment

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    incognia_api (1.2.0)
+    incognia_api (1.3.0)
       faraday (~> 1.10)
       faraday_middleware (~> 1.2)
 

--- a/README.md
+++ b/README.md
@@ -35,16 +35,18 @@ Or install it yourself as:
 
 ### Configuration
 
-Before using the API client, you must initialize it using credentials obtained
-from the [Incognia dashboard]():
+Before using the API client, you must configure it using credentials obtained
+from the [Incognia dashboard](https://dash.incognia.com/):
 
 ```ruby
-api = Incognia::Api.new(client_id: "your-client-id", client_secret:
-"your-client-secret")
+Incognia.configure(client_id: ENV['INCOGNIA_CLIENT_ID'], client_secret: ENV['INCOGNIA_CLIENT_SECRET'])
 
+# Incognia.configure(client_id: "your-client-id", client_secret: "your-client-secret")
 ```
 
-For sandbox credentials, refer to the [API testing guide]().
+For sandbox credentials, refer to the [API testing guide](https://developer.incognia.com/).
+
+:bulb: For Rails applications it's recommended to create an initializer file, for example `config/initializers/incognia.rb`.
 
 
 ### Registering a Signup
@@ -55,7 +57,7 @@ This method registers a new signup for the given request token and address, retu
 address = Incognia::Address.new(line: "West 34th Street, New York City, NY 10001")
 request_token = "WlMksW+jh5GPhqWBorsV8yDihoSHHpmt+DpjJ7eYxpHhuO/5tuHTuA..."
 
-assessment = api.register_signup(
+assessment = Incognia::Api.register_signup(
   request_token: request_token,
   address: address
 )
@@ -71,7 +73,7 @@ address = Incognia::Address.new(line: "West 34th Street, New York City, NY 10001
 request_token = "WlMksW+jh5GPhqWBorsV8yDihoSHHpmt+DpjJ7eYxpHhuO/5tuHTuA..."
 external_id = "7b02736a-7718-4b83-8982-f68fb6f501fa"
 
-assessment = api.register_signup(
+assessment = Incognia::Api.register_signup(
   request_token: request_token,
   address: address,
   external_id: external_id
@@ -88,7 +90,7 @@ This method registers a new login for the given request token and account, retur
 request_token = "WlMksW+jh5GPhqWBorsV8yDihoSHHpmt+DpjJ7eYxpHhuO/5tuHTuA..."
 account_id = 'account-identifier-123'
 
-assessment = api.register_login(
+assessment = Incognia::Api.register_login(
   request_token: request_token,
   account_id: account_id,
 )
@@ -104,7 +106,7 @@ request_token = "WlMksW+jh5GPhqWBorsV8yDihoSHHpmt+DpjJ7eYxpHhuO/5tuHTuA..."
 account_id = 'account-identifier-123'
 external_id = 'some-external-identifier'
 
-assessment = api.register_login(
+assessment = Incognia::Api.register_login(
   request_token: request_token,
   account_id: account_id,
   external_id: external_id,
@@ -120,7 +122,7 @@ This method registers a new payment for the given request token and account, ret
 containing the risk assessment and supporting evidence.
 
 ```ruby
-assessment = api.register_payment(
+assessment = Incognia::Api.register_payment(
   request_token: 'request-token',
   account_id: 'account-id'
 )
@@ -180,7 +182,7 @@ payment_methods = [
   }
 ]
 
-assessment = api.register_payment(
+assessment = Incognia::Api.register_payment(
   request_token: 'request-token',
   account_id: 'account-id',
   external_id: 'external-id',
@@ -206,7 +208,7 @@ request_token = 'request-token'
 account_id = 'account-id'
 occurred_at = DateTime.parse('2024-07-22T15:20:00Z')
 
-success = api.register_feedback(
+success = Incognia::Api.register_feedback(
   event: Incognia::Constants::FeedbackEvent::ACCOUNT_TAKEOVER,
   occurred_at: occurred_at,
   request_token: request_token,
@@ -219,7 +221,7 @@ success = api.register_feedback(
 For custom fraud, set the value of `event` with the corresponding code:
 
 ```ruby
-success = api.register_feedback(
+success = Incognia::Api.register_feedback(
   event: 'custom_fraud_name',
   occurred_at: occurred_at,
   request_token: request_token,

--- a/lib/incognia_api.rb
+++ b/lib/incognia_api.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "incognia_api/configuration"
 require_relative "incognia_api/version"
 require_relative "incognia_api/client"
 require_relative "incognia_api/util"
@@ -15,6 +16,14 @@ require_relative "incognia_api/resources/credentials"
 require_relative "incognia_api/constants/feedback_event"
 
 module Incognia
+  def self.configure(**args)
+    config.configure(**args)
+  end
+
+  def self.config
+    Configuration.instance
+  end
+
   class APIError < StandardError
     attr_reader :message, :errors, :status
 

--- a/lib/incognia_api/api.rb
+++ b/lib/incognia_api/api.rb
@@ -5,83 +5,96 @@ require 'faraday_middleware'
 
 module Incognia
   class Api
-    # business layer: uses the Client to build domain objects
+    # business layer: uses the Client.instance to build domain objects
     # raises missing parameters errors
-    attr_accessor :connection
 
     def initialize(client_id:, client_secret:)
-      @connection = Client.new(client_id: client_id,
-                               client_secret: client_secret,
-                               host: "https://api.incognia.com/api")
+      Incognia.configure(client_id: client_id, client_secret: client_secret)
+
+      warn("Deprecation warning: The Incognia::Api instance will be removed. " +
+           "Please set up with `Incognia.configure` and use class methods instead.")
     end
 
-    def register_signup(request_token: nil, address: nil, **opts)
-      params = { request_token: request_token }.compact
-      params.merge!(opts)
-      params.merge!(address&.to_hash) if address
+    def register_signup(**args); self.class.register_signup(**args) end
+    def register_login(**args); self.class.register_login(**args) end
+    def register_feedback(**args); self.class.register_feedback(**args) end
+    def register_payment(**args); self.class.register_payment(**args) end
 
-      response = connection.request(
-        :post,
-        'v2/onboarding/signups',
-        params
-      )
+    class << self
+      def register_signup(request_token: nil, address: nil, **opts)
+        params = { request_token: request_token }.compact
+        params.merge!(opts)
+        params.merge!(address&.to_hash) if address
 
-      SignupAssessment.from_hash(response.body) if response.success?
-    end
+        response = connection.request(
+          :post,
+          'v2/onboarding/signups',
+          params
+        )
 
-    def register_login(account_id:, request_token: nil, **opts)
-      params = {
-        type: :login,
-        account_id: account_id,
-        request_token: request_token
-      }.compact
-      params.merge!(opts)
-
-      response = connection.request(
-        :post,
-        'v2/authentication/transactions',
-        params
-      )
-
-      LoginAssessment.from_hash(response.body) if response.success?
-    end
-
-    def register_feedback(event:, occurred_at: nil, expires_at: nil, timestamp: nil, **ids)
-      if !timestamp.nil?
-        warn("Deprecation warning: use occurred_at instead of timestamp")
+        SignupAssessment.from_hash(response.body) if response.success?
       end
 
-      timestamp = timestamp.strftime('%s%L') if timestamp.respond_to? :strftime
-      occurred_at = occurred_at.to_datetime.rfc3339 if occurred_at.respond_to? :to_datetime
-      expires_at = expires_at.to_datetime.rfc3339 if expires_at.respond_to? :to_datetime
+      def register_login(account_id:, request_token: nil, **opts)
+        params = {
+          type: :login,
+          account_id: account_id,
+          request_token: request_token
+        }.compact
+        params.merge!(opts)
 
-      params = { event: event, timestamp: timestamp&.to_i, occurred_at: occurred_at, expires_at: expires_at }.compact
-      params.merge!(ids)
+        response = connection.request(
+          :post,
+          'v2/authentication/transactions',
+          params
+        )
 
-      response = connection.request(
-        :post,
-        '/api/v2/feedbacks',
-        params
-      )
+        LoginAssessment.from_hash(response.body) if response.success?
+      end
 
-      response.success?
-    end
+      def register_feedback(event:, occurred_at: nil, expires_at: nil, timestamp: nil, **ids)
+        if !timestamp.nil?
+          warn("Deprecation warning: use occurred_at instead of timestamp")
+        end
 
-    def register_payment(account_id:, request_token: nil, **opts)
-      params = {
-        type: :payment,
-        account_id: account_id,
-        request_token: request_token
-      }.compact
-      params.merge!(opts)
+        timestamp = timestamp.strftime('%s%L') if timestamp.respond_to? :strftime
+        occurred_at = occurred_at.to_datetime.rfc3339 if occurred_at.respond_to? :to_datetime
+        expires_at = expires_at.to_datetime.rfc3339 if expires_at.respond_to? :to_datetime
 
-      response = connection.request(
-        :post,
-        'v2/authentication/transactions',
-        params
-      )
+        params = { event: event, timestamp: timestamp&.to_i, occurred_at: occurred_at, expires_at: expires_at }.compact
+        params.merge!(ids)
 
-      PaymentAssessment.from_hash(response.body) if response.success?
+        response = connection.request(
+          :post,
+          '/api/v2/feedbacks',
+          params
+        )
+
+        response.success?
+      end
+
+      def register_payment(account_id:, request_token: nil, **opts)
+        params = {
+          type: :payment,
+          account_id: account_id,
+          request_token: request_token
+        }.compact
+        params.merge!(opts)
+
+        response = connection.request(
+          :post,
+          'v2/authentication/transactions',
+          params
+        )
+
+        PaymentAssessment.from_hash(response.body) if response.success?
+      end
+
+      private
+
+      def connection
+        Client.instance
+      end
     end
   end
 end

--- a/lib/incognia_api/api.rb
+++ b/lib/incognia_api/api.rb
@@ -19,6 +19,11 @@ module Incognia
     def register_login(**args); self.class.register_login(**args) end
     def register_feedback(**args); self.class.register_feedback(**args) end
     def register_payment(**args); self.class.register_payment(**args) end
+    def connection
+      warn("Deprecation warning: #connection and .connection are deprecated and will be private.")
+
+      self.class.connection
+    end
 
     class << self
       def register_signup(request_token: nil, address: nil, **opts)
@@ -89,8 +94,6 @@ module Incognia
 
         PaymentAssessment.from_hash(response.body) if response.success?
       end
-
-      private
 
       def connection
         Client.instance

--- a/lib/incognia_api/client.rb
+++ b/lib/incognia_api/client.rb
@@ -30,8 +30,6 @@ module Incognia
       @credentials
     end
 
-    protected
-
     def connection
       return @connection if @connection
 
@@ -48,6 +46,8 @@ module Incognia
         faraday.adapter Faraday.default_adapter
       end
     end
+
+    protected
 
     def request_credentials
       basic_auth = Faraday::Request

--- a/lib/incognia_api/client.rb
+++ b/lib/incognia_api/client.rb
@@ -1,32 +1,14 @@
 require "time"
+require "singleton"
 
 module Incognia
   class Client
+    include Singleton
     # TODO:
     # (ok) http/adapter specific code
     # (ok) raises network/authentication errors
     # (ok) handles token refreshing ok
     # future: handles retrying
-    attr_reader :connection
-
-    def initialize(client_id:, client_secret:, host:)
-      @client_id = client_id
-      @client_secret = client_secret
-      @host = host
-
-      headers = { 'User-Agent' => "incognia-ruby/#{Incognia::VERSION} " \
-                          "({#{RbConfig::CONFIG['host']}}) " \
-                          "{#{RbConfig::CONFIG['arch']}} " \
-                          "Ruby/#{RbConfig::CONFIG['ruby_version']}" }
-
-      @connection = Faraday.new(host, headers: headers) do |faraday|
-        faraday.request :json
-        faraday.response :json, content_type: /\bjson$/
-        faraday.response :raise_error
-
-        faraday.adapter Faraday.default_adapter
-      end
-    end
 
     def request(method, endpoint = nil, data = nil, headers = {})
       json_data = JSON.generate(data) if data
@@ -50,10 +32,27 @@ module Incognia
 
     protected
 
+    def connection
+      return @connection if @connection
+
+      headers = { 'User-Agent' => "incognia-ruby/#{Incognia::VERSION} " \
+                          "({#{RbConfig::CONFIG['host']}}) " \
+                          "{#{RbConfig::CONFIG['arch']}} " \
+                          "Ruby/#{RbConfig::CONFIG['ruby_version']}" }
+
+      @connection = Faraday.new(Incognia.config.host, headers: headers) do |faraday|
+        faraday.request :json
+        faraday.response :json, content_type: /\bjson$/
+        faraday.response :raise_error
+
+        faraday.adapter Faraday.default_adapter
+      end
+    end
+
     def request_credentials
       basic_auth = Faraday::Request
         .lookup_middleware(:basic_auth)
-        .header(@client_id, @client_secret)
+        .header(Incognia.config.client_id, Incognia.config.client_secret)
 
       response = connection.send(:post, 'v2/token') do |r|
         r.headers[Faraday::Request::Authorization::KEY] = basic_auth

--- a/lib/incognia_api/configuration.rb
+++ b/lib/incognia_api/configuration.rb
@@ -1,0 +1,17 @@
+require 'singleton'
+
+module Incognia
+  class Configuration
+    include Singleton
+
+    attr_accessor :client_id, :client_secret, :host
+
+    def configure(client_id:, client_secret:, host: nil)
+      @client_id = client_id
+      @client_secret = client_secret
+      @host = host || 'https://api.incognia.com/api'
+
+      self
+    end
+  end
+end

--- a/lib/incognia_api/version.rb
+++ b/lib/incognia_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Incognia
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/spec/incognia_spec.rb
+++ b/spec/incognia_spec.rb
@@ -25,11 +25,15 @@ module Incognia
   end
 
   RSpec.describe Incognia::Api do
-    subject(:api) do
-      Api.new(client_id: 'client_id', client_secret: 'client_secret')
+    before do
+      Incognia.configure(
+        client_id: 'client_id',
+        client_secret: 'client_secret',
+        host: 'https://api.incognia.com/api'
+      )
     end
 
-    describe "#register_signup" do
+    describe ".register_signup" do
       let(:locale) { "en-US" }
       let(:country_name) { "United States of America" }
       let(:country_code) { "US" }
@@ -69,7 +73,7 @@ module Incognia
         stub_token_request
         stub_signup_request
 
-        signup = api.register_signup(request_token: request_token, address: address)
+        signup = described_class.register_signup(request_token: request_token, address: address)
 
         expected = JSON.parse(unknown_signup_fixture, symbolize_names: true)
         expect(signup.id).
@@ -94,7 +98,7 @@ module Incognia
               }
             )
 
-            api.register_signup(token_name => token_value)
+            described_class.register_signup(token_name => token_value)
 
             expect(stub).to have_been_made.once
           end
@@ -114,7 +118,7 @@ module Incognia
             }
           )
 
-          api.register_signup(request_token: request_token, address: address)
+          described_class.register_signup(request_token: request_token, address: address)
 
           expect(stub).to have_been_made.once
         end
@@ -130,7 +134,7 @@ module Incognia
             }
           )
 
-          api.register_signup(request_token: request_token, address: structured_address)
+          described_class.register_signup(request_token: request_token, address: structured_address)
 
           expect(stub).to have_been_made.once
         end
@@ -146,7 +150,7 @@ module Incognia
             }
           )
 
-          api.register_signup(request_token: request_token, address: coordinates_address)
+          described_class.register_signup(request_token: request_token, address: coordinates_address)
 
           expect(stub).to have_been_made.once
         end
@@ -163,7 +167,7 @@ module Incognia
                 }
               )
 
-              api.register_signup(
+              described_class.register_signup(
                 request_token: request_token,
                 **opts
               )
@@ -185,7 +189,7 @@ module Incognia
       end
     end
 
-    describe "#register_login" do
+    describe ".register_login" do
       let(:request_token) { SecureRandom.uuid }
       let(:account_id) { SecureRandom.uuid }
 
@@ -193,7 +197,7 @@ module Incognia
         stub_token_request
         stub_login_request
 
-        login = api.register_login(
+        login = described_class.register_login(
           request_token: request_token,
           account_id: account_id
         )
@@ -222,7 +226,7 @@ module Incognia
               }
             )
 
-            api.register_login(
+            described_class.register_login(
               account_id: account_id,
               token_name => token_value
             )
@@ -251,7 +255,7 @@ module Incognia
                 }
               )
 
-              api.register_login(
+              described_class.register_login(
                 request_token: request_token,
                 account_id: account_id,
                 **opts
@@ -275,7 +279,7 @@ module Incognia
 
     end
 
-    describe "#register_payment" do
+    describe ".register_payment" do
       let(:request_token) { SecureRandom.uuid }
       let(:account_id) { SecureRandom.uuid }
 
@@ -283,7 +287,7 @@ module Incognia
         stub_token_request
         stub_payment_request
 
-        payment = api.register_payment(
+        payment = described_class.register_payment(
           request_token: request_token,
           account_id: account_id
         )
@@ -312,7 +316,7 @@ module Incognia
               }
             )
 
-            api.register_payment(
+            described_class.register_payment(
               account_id: account_id,
               token_name => token_value
             )
@@ -341,7 +345,7 @@ module Incognia
                 }
               )
 
-              api.register_payment(
+              described_class.register_payment(
                 request_token: request_token,
                 account_id: account_id,
                 **opts
@@ -364,26 +368,31 @@ module Incognia
       end
     end
 
-    describe "#register_feedback" do
+    describe ".register_feedback" do
       let(:event) { Incognia::Constants::FeedbackEvent.constants.sample.to_s }
       let(:timestamp) { 1655749693000 }
       let(:expires_at) { '2024-03-13T10:12:01Z' }
 
-      before { stub_token_request }
+      before do
+        allow(described_class).to receive(:warn)
+
+        stub_token_request
+      end
+
 
       it "when successful returns true" do
         stub_register_feedback_request
 
-        feedback_registered = api.register_feedback(event: event, timestamp: timestamp)
+        feedback_registered = described_class.register_feedback(event: event, timestamp: timestamp)
         expect(feedback_registered).to be(true)
       end
 
       it "warns about the deprecation of timestamp" do
         stub_register_feedback_request
 
-        expect(api).to receive(:warn).with("Deprecation warning: use occurred_at instead of timestamp")
+        expect(described_class).to receive(:warn).with("Deprecation warning: use occurred_at instead of timestamp")
 
-        api.register_feedback(event: event, timestamp: timestamp)
+        described_class.register_feedback(event: event, timestamp: timestamp)
       end
 
       context "HTTP request" do
@@ -396,7 +405,7 @@ module Incognia
             }
           )
 
-          api.register_feedback(event: event, timestamp: timestamp, expires_at: expires_at)
+          described_class.register_feedback(event: event, timestamp: timestamp, expires_at: expires_at)
 
           expect(stub).to have_been_made.once
         end
@@ -412,7 +421,7 @@ module Incognia
               }
             )
 
-            api.register_feedback(event: event, timestamp: timestamp)
+            described_class.register_feedback(event: event, timestamp: timestamp)
 
             expect(stub).to have_been_made.once
           end
@@ -429,7 +438,7 @@ module Incognia
               }
             )
 
-            api.register_feedback(event: event, timestamp: timestamp)
+            described_class.register_feedback(event: event, timestamp: timestamp)
 
             expect(stub).to have_been_made.once
           end
@@ -444,7 +453,7 @@ module Incognia
               }
             )
 
-            api.register_feedback(event: event)
+            described_class.register_feedback(event: event)
 
             expect(stub).to have_been_made.once
           end
@@ -461,7 +470,7 @@ module Incognia
               }
             )
 
-            api.register_feedback(event: event, occurred_at: occurred_at)
+            described_class.register_feedback(event: event, occurred_at: occurred_at)
 
             expect(stub).to have_been_made.once
           end
@@ -478,7 +487,7 @@ module Incognia
               }
             )
 
-            api.register_feedback(event: event, occurred_at: occurred_at)
+            described_class.register_feedback(event: event, occurred_at: occurred_at)
 
             expect(stub).to have_been_made.once
           end
@@ -495,7 +504,7 @@ module Incognia
               }
             )
 
-            api.register_feedback(event: event, expires_at: expires_at)
+            described_class.register_feedback(event: event, expires_at: expires_at)
 
             expect(stub).to have_been_made.once
           end
@@ -512,7 +521,7 @@ module Incognia
               }
             )
 
-            api.register_feedback(event: event, expires_at: expires_at)
+            described_class.register_feedback(event: event, expires_at: expires_at)
 
             expect(stub).to have_been_made.once
           end
@@ -527,7 +536,7 @@ module Incognia
               }
             )
 
-            api.register_feedback(event: event)
+            described_class.register_feedback(event: event)
 
             expect(stub).to have_been_made.once
           end
@@ -545,7 +554,7 @@ module Incognia
                 }
               )
 
-              api.register_feedback(event: event, timestamp: timestamp, expires_at: expires_at, id_name => id)
+              described_class.register_feedback(event: event, timestamp: timestamp, expires_at: expires_at, id_name => id)
 
               expect(stub).to have_been_made.once
             end
@@ -569,6 +578,66 @@ module Incognia
         to eql expected[:evidence][:location_services][:location_permission_enabled]
       expect(model.evidence.location_services.location_sensors_enabled).
         to eql expected[:evidence][:location_services][:location_sensors_enabled]
+    end
+
+    context 'deprecated instance' do
+      let(:api_instance) do
+        described_class.new(client_id: 'id', client_secret: 'secret')
+      end
+
+      before do
+        allow_any_instance_of(described_class).to receive(:warn)
+      end
+
+      describe 'initialization' do
+        it 'configures Incognia with client_id and client_secret' do
+          expect(Incognia).to receive(:configure).with(
+            client_id: 'id',
+            client_secret: 'secret'
+          )
+
+          api_instance
+        end
+      end
+
+      shared_examples_for 'instance method delegation' do |method, args|
+        it "calls Incognia.#{method}" do
+          expect(described_class).to receive(method).with(**args)
+
+          api_instance.method(method).call(**args)
+        end
+      end
+
+      describe '#register_signup' do
+        it_behaves_like 'instance method delegation', :register_signup, {
+          request_token: 'request_token',
+          address: 'address',
+          account_id: 'account_id'
+        }
+      end
+
+      describe '#register_login' do
+        it_behaves_like 'instance method delegation', :register_login, {
+          account_id: 'account_id',
+          request_token: 'token',
+          external_id: 'external_id'
+        }
+      end
+
+      describe '#register_payment' do
+        it_behaves_like 'instance method delegation', :register_payment, {
+          account_id: 'account_id',
+          request_token: 'token',
+          external_id: 'external_id'
+        }
+      end
+
+      describe '#register_feedback' do
+        it_behaves_like 'instance method delegation', :register_feedback, {
+          event: 'event',
+          account_id: 'account_id'
+        }
+      end
     end
   end
 end

--- a/spec/incognia_spec.rb
+++ b/spec/incognia_spec.rb
@@ -638,6 +638,20 @@ module Incognia
           account_id: 'account_id'
         }
       end
+
+      describe '#connection' do
+        it 'calls Incognia.connection' do
+          expect(described_class).to receive(:connection)
+
+          api_instance.connection
+        end
+
+        it 'warns about deprecation of #connection and .connection' do
+          expect(api_instance).to receive(:warn).with("Deprecation warning: #connection and .connection are deprecated and will be private.")
+
+          api_instance.connection
+        end
+      end
     end
   end
 end

--- a/spec/incognia_spec.rb
+++ b/spec/incognia_spec.rb
@@ -2,6 +2,28 @@
 require 'securerandom'
 
 module Incognia
+  RSpec.describe '.configure' do
+    it 'sets configuration on Configuration.instance' do
+      config = {
+        client_id: SecureRandom.uuid,
+        client_secret: SecureRandom.uuid,
+        host: 'https://api.incognia.com/api'
+      }
+
+      Incognia.configure(**config)
+
+      expect(Configuration.instance.client_id).to eq(config[:client_id])
+      expect(Configuration.instance.client_secret).to eq(config[:client_secret])
+      expect(Configuration.instance.host).to eq(config[:host])
+    end
+  end
+
+  RSpec.describe '.config' do
+    it 'returns the instance of Configuration' do
+      expect(Incognia.config).to eq(Configuration.instance)
+    end
+  end
+
   RSpec.describe Incognia::Api do
     subject(:api) do
       Api.new(client_id: 'client_id', client_secret: 'client_secret')


### PR DESCRIPTION
Sometimes a developer doesn't reuse the `Incognia::Api` instance. As a consequence loses the token cache, making unnecessary requests for a new token.

This PR defines `Incognia::Api` static methods and creates a Singleton to ensure the token reuse.

Proposed usage
```ruby
Incognia.configure(client_id: ENV['INCOGNIA_CLIENT_ID'], client_secret: ENV['INCOGNIA_CLIENT_SECRET'])

assessment = Incognia::Api.register_login(
  request_token: request_token,
  account_id: account_id,
)

```

Previous usage

```ruby
api = Incognia::Api.new(client_id: "your-client-id", client_secret: "your-client-secret")

assessment = api.register_login(
  request_token: request_token,
  account_id: account_id,
)
```

:bulb: Review by commit