### PR TITLE
feat: add location parameter for transactions endpoint requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [2.1.0] - 2025-05-09
+
+- Add support for passing an optional location parameter to register logins and payments
+
 ## [2.0.0] - 2024-11-12
 
 - Remove support for instance usage of Incognia::Api

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    incognia_api (2.0.0)
+    incognia_api (2.1.0)
       faraday (~> 1.10)
       faraday_middleware (~> 1.2)
 

--- a/lib/incognia_api.rb
+++ b/lib/incognia_api.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'time'
+
 require_relative "incognia_api/configuration"
 require_relative "incognia_api/version"
 require_relative "incognia_api/client"

--- a/lib/incognia_api.rb
+++ b/lib/incognia_api.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
-
+require 'time'
 require_relative "incognia_api/configuration"
 require_relative "incognia_api/version"
 require_relative "incognia_api/client"
 require_relative "incognia_api/util"
 require_relative "incognia_api/address"
 require_relative "incognia_api/api"
+require_relative "incognia_api/location"
 
 require_relative "incognia_api/resources/api_resource"
 require_relative "incognia_api/resources/signup_assessment"

--- a/lib/incognia_api/api.rb
+++ b/lib/incognia_api/api.rb
@@ -29,7 +29,7 @@ module Incognia
           account_id: account_id,
           request_token: request_token
         }.compact
-        params.merge!(location&.to_hash) if location
+        params.merge!(location: location&.to_hash) if location
         params.merge!(opts)
 
         response = connection.request(
@@ -63,7 +63,7 @@ module Incognia
           account_id: account_id,
           request_token: request_token
         }.compact
-        params.merge!(location&.to_hash) if location
+        params.merge!(location: location&.to_hash) if location
         params.merge!(opts)
 
         response = connection.request(

--- a/lib/incognia_api/api.rb
+++ b/lib/incognia_api/api.rb
@@ -12,7 +12,7 @@ module Incognia
       def register_signup(request_token: nil, address: nil, **opts)
         params = { request_token: request_token }.compact
         params.merge!(opts)
-        params.merge!(address&.to_hash) if address
+        params.merge!(address.to_hash) if address
 
         response = connection.request(
           :post,
@@ -29,7 +29,7 @@ module Incognia
           account_id: account_id,
           request_token: request_token
         }.compact
-        params.merge!(location: location&.to_hash) if location
+        params.merge!(location: location.to_hash) if location
         params.merge!(opts)
 
         response = connection.request(
@@ -63,7 +63,7 @@ module Incognia
           account_id: account_id,
           request_token: request_token
         }.compact
-        params.merge!(location: location&.to_hash) if location
+        params.merge!(location: location.to_hash) if location
         params.merge!(opts)
 
         response = connection.request(

--- a/lib/incognia_api/api.rb
+++ b/lib/incognia_api/api.rb
@@ -23,12 +23,13 @@ module Incognia
         SignupAssessment.from_hash(response.body) if response.success?
       end
 
-      def register_login(account_id:, request_token: nil, **opts)
+      def register_login(account_id:, request_token: nil, location: nil, **opts)
         params = {
           type: :login,
           account_id: account_id,
           request_token: request_token
         }.compact
+        params.merge!(location&.to_hash) if location
         params.merge!(opts)
 
         response = connection.request(
@@ -56,12 +57,13 @@ module Incognia
         response.success?
       end
 
-      def register_payment(account_id:, request_token: nil, **opts)
+      def register_payment(account_id:, request_token: nil, location: nil, **opts)
         params = {
           type: :payment,
           account_id: account_id,
           request_token: request_token
         }.compact
+        params.merge!(location&.to_hash) if location
         params.merge!(opts)
 
         response = connection.request(

--- a/lib/incognia_api/location.rb
+++ b/lib/incognia_api/location.rb
@@ -7,29 +7,17 @@ module Incognia
     def initialize(latitude:, longitude:, collected_at: nil)
         @latitude = latitude
         @longitude = longitude
-        @collected_at = parse_timestamp(collected_at)
+        @collected_at = collected_at
     end
 
     def to_hash
       location = {
         latitude: latitude,
         longitude: longitude,
-        collected_at:  collected_at&.iso8601
+        collected_at: collected_at.respond_to?(:to_datetime) ? collected_at.to_datetime.rfc3339 : collected_at,
       }.compact
 
       location
     end
-      
-    private
-
-    def parse_timestamp(timestamp)
-      return nil unless timestamp
-    
-      begin
-        Time.iso8601(timestamp)
-      rescue ArgumentError
-        raise ArgumentError, "Location 'collected_at' attribute not in RFC3339 format: #{timestamp}"
-      end
-    end    
   end
 end

--- a/lib/incognia_api/location.rb
+++ b/lib/incognia_api/location.rb
@@ -1,7 +1,7 @@
 require 'time'
 
 module Incognia
-    class Location
+  class Location
     attr_reader :latitude, :longitude, :collected_at
 
     def initialize(latitude:, longitude:, collected_at: nil)
@@ -11,24 +11,25 @@ module Incognia
     end
 
     def to_hash
-        hash = {
-          latitude: latitude,
-          longitude: longitude
-        }
-        hash[:collected_at] = collected_at.iso8601 if collected_at
-      
-        {
-          location: hash
-        }
-      end
+      location = {
+        latitude: latitude,
+        longitude: longitude,
+        collected_at:  collected_at&.iso8601
+      }.compact
+
+      location
+    end
       
     private
 
     def parse_timestamp(timestamp)
-        return nil unless timestamp
+      return nil unless timestamp
+    
+      begin
         Time.iso8601(timestamp)
-    rescue ArgumentError
+      rescue ArgumentError
         raise ArgumentError, "Location 'collected_at' attribute not in RFC3339 format: #{timestamp}"
-    end
-    end
+      end
+    end    
+  end
 end

--- a/lib/incognia_api/location.rb
+++ b/lib/incognia_api/location.rb
@@ -1,0 +1,34 @@
+require 'time'
+
+module Incognia
+    class Location
+    attr_reader :latitude, :longitude, :collected_at
+
+    def initialize(latitude:, longitude:, collected_at: nil)
+        @latitude = latitude
+        @longitude = longitude
+        @collected_at = parse_timestamp(collected_at)
+    end
+
+    def to_hash
+        hash = {
+          latitude: latitude,
+          longitude: longitude
+        }
+        hash[:collected_at] = collected_at.iso8601 if collected_at
+      
+        {
+          location: hash
+        }
+      end
+      
+    private
+
+    def parse_timestamp(timestamp)
+        return nil unless timestamp
+        Time.iso8601(timestamp)
+    rescue ArgumentError
+        raise ArgumentError, "Location 'collected_at' attribute not in RFC3339 format: #{timestamp}"
+    end
+    end
+end

--- a/lib/incognia_api/version.rb
+++ b/lib/incognia_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Incognia
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -36,7 +36,7 @@ module Incognia
         stub = stub_request(:post, test_endpoint).
           with(
             body: sample_json,
-            headers: { 'Authorization'=> "Bearer #{JSON.parse(token_fixture)["access_token"]}" }
+            headers: { 'Authorization'=> /Bearer .+/}
           ).
           to_return(
             status: 200,

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -36,7 +36,7 @@ module Incognia
         stub = stub_request(:post, test_endpoint).
           with(
             body: sample_json,
-            headers: { 'Authorization'=> /Bearer .+/}
+            headers: { 'Authorization'=> "Bearer #{JSON.parse(token_fixture)["access_token"]}" }
           ).
           to_return(
             status: 200,

--- a/spec/incognia_spec.rb
+++ b/spec/incognia_spec.rb
@@ -239,18 +239,18 @@ module Incognia
         it_behaves_like 'receiving one of the required tokens with account_id', :installation_id
         it_behaves_like 'receiving one of the required tokens with account_id', :session_token
 
-        context 'when location is provided' do
-          let(:location) { Location.new(latitude: 37.7749, longitude: -122.4194, collected_at: "2025-04-27T05:03:45-02:00") }
+        shared_examples_for 'a login request that includes location in the request body' do
 
           it 'includes location in the request body' do
             stub_token_request
-
+        
             body = {
               type: 'login',
               request_token: request_token,
-              account_id: account_id
-            }.merge(location.to_hash)
-
+              account_id: account_id,
+              location: location&.to_hash,
+            }
+        
             stub = stub_login_request.with(
               body: body,
               headers: {
@@ -258,7 +258,7 @@ module Incognia
                 'Authorization' => /Bearer.*/
               }
             )
-
+        
             described_class.register_login(
               request_token: request_token,
               account_id: account_id,
@@ -268,7 +268,17 @@ module Incognia
             expect(stub).to have_been_made.once
           end
         end
-        
+
+        context 'when location with a timestamp is provided' do
+          let(:location) { Location.new(latitude: 37.7749, longitude: -122.4194, collected_at: "2025-04-27T05:03:45-02:00") }
+          it_behaves_like 'a login request that includes location in the request body'
+        end
+
+        context 'when location without a timestamp is provided' do
+          let(:location) { Location.new(latitude: 37.7749, longitude: -122.4194) }
+          it_behaves_like 'a login request that includes location in the request body'
+        end
+  
         context 'when receiving any other optional arguments' do
           shared_examples_for 'receiving optional args' do |optional_arguments|
             it "hits the endpoint also with #{optional_arguments}" do
@@ -359,18 +369,17 @@ module Incognia
         it_behaves_like 'receiving one of the required tokens with account_id', :installation_id
         it_behaves_like 'receiving one of the required tokens with account_id', :session_token
 
-        context 'when location is provided' do
-          let(:location) { Location.new(latitude: 37.7749, longitude: -122.4194, collected_at: "2025-04-27T05:03:45-02:00") }
-
+        shared_examples_for 'a payment request that includes location in the request body' do
           it 'includes location in the request body' do
             stub_token_request
-
+        
             body = {
               type: 'payment',
               request_token: request_token,
-              account_id: account_id
-            }.merge(location.to_hash)
-
+              account_id: account_id,
+              location: location&.to_hash,
+            }
+        
             stub = stub_payment_request.with(
               body: body,
               headers: {
@@ -378,7 +387,7 @@ module Incognia
                 'Authorization' => /Bearer.*/
               }
             )
-
+        
             described_class.register_payment(
               request_token: request_token,
               account_id: account_id,
@@ -387,6 +396,16 @@ module Incognia
         
             expect(stub).to have_been_made.once
           end
+        end
+
+        context 'when location with a timestamp is provided' do
+          let(:location) { Location.new(latitude: 37.7749, longitude: -122.4194) }
+          it_behaves_like 'a payment request that includes location in the request body'
+        end
+
+        context 'when location without a timestamp is provided' do
+          let(:location) { Location.new(latitude: 37.7749, longitude: -122.4194) }
+          it_behaves_like 'a payment request that includes location in the request body'
         end
 
         context 'when receiving any other optional arguments' do

--- a/spec/incognia_spec.rb
+++ b/spec/incognia_spec.rb
@@ -248,7 +248,7 @@ module Incognia
               type: 'login',
               request_token: request_token,
               account_id: account_id,
-              location: location&.to_hash,
+              location: location.to_hash,
             }
         
             stub = stub_login_request.with(
@@ -377,7 +377,7 @@ module Incognia
               type: 'payment',
               request_token: request_token,
               account_id: account_id,
-              location: location&.to_hash,
+              location: location.to_hash,
             }
         
             stub = stub_payment_request.with(

--- a/spec/incognia_spec.rb
+++ b/spec/incognia_spec.rb
@@ -399,7 +399,7 @@ module Incognia
         end
 
         context 'when location with a timestamp is provided' do
-          let(:location) { Location.new(latitude: 37.7749, longitude: -122.4194) }
+          let(:location) { Location.new(latitude: 37.7749, longitude: -122.4194, collected_at: "2025-04-27T05:03:45-02:00") }
           it_behaves_like 'a payment request that includes location in the request body'
         end
 

--- a/spec/incognia_spec.rb
+++ b/spec/incognia_spec.rb
@@ -239,6 +239,36 @@ module Incognia
         it_behaves_like 'receiving one of the required tokens with account_id', :installation_id
         it_behaves_like 'receiving one of the required tokens with account_id', :session_token
 
+        context 'when location is provided' do
+          let(:location) { Location.new(latitude: 37.7749, longitude: -122.4194, collected_at: "2025-04-27T05:03:45-02:00") }
+
+          it 'includes location in the request body' do
+            stub_token_request
+
+            body = {
+              type: 'login',
+              request_token: request_token,
+              account_id: account_id
+            }.merge(location.to_hash)
+
+            stub = stub_login_request.with(
+              body: body,
+              headers: {
+                'Content-Type' => 'application/json',
+                'Authorization' => /Bearer.*/
+              }
+            )
+
+            described_class.register_login(
+              request_token: request_token,
+              account_id: account_id,
+              location: location,
+            )
+        
+            expect(stub).to have_been_made.once
+          end
+        end
+        
         context 'when receiving any other optional arguments' do
           shared_examples_for 'receiving optional args' do |optional_arguments|
             it "hits the endpoint also with #{optional_arguments}" do
@@ -328,6 +358,36 @@ module Incognia
         it_behaves_like 'receiving one of the required tokens with account_id', :request_token
         it_behaves_like 'receiving one of the required tokens with account_id', :installation_id
         it_behaves_like 'receiving one of the required tokens with account_id', :session_token
+
+        context 'when location is provided' do
+          let(:location) { Location.new(latitude: 37.7749, longitude: -122.4194, collected_at: "2025-04-27T05:03:45-02:00") }
+
+          it 'includes location in the request body' do
+            stub_token_request
+
+            body = {
+              type: 'payment',
+              request_token: request_token,
+              account_id: account_id
+            }.merge(location.to_hash)
+
+            stub = stub_payment_request.with(
+              body: body,
+              headers: {
+                'Content-Type' => 'application/json',
+                'Authorization' => /Bearer.*/
+              }
+            )
+
+            described_class.register_payment(
+              request_token: request_token,
+              account_id: account_id,
+              location: location,
+            )
+        
+            expect(stub).to have_been_made.once
+          end
+        end
 
         context 'when receiving any other optional arguments' do
           shared_examples_for 'receiving optional args' do |optional_arguments|

--- a/spec/location_spec.rb
+++ b/spec/location_spec.rb
@@ -1,0 +1,88 @@
+require "spec_helper"
+
+module Incognia
+  RSpec.describe Location do
+    let(:latitude) { 12.123 }
+    let(:longitude) { -7.123 }
+    let(:collected_at) { "2025-04-23T12:12:12-03:00" }
+    let(:simple_format) do
+      {
+        latitude: latitude,
+        longitude: longitude,
+      }
+    end
+    let(:complete_format) do
+      {
+        latitude: latitude,
+        longitude: longitude,
+        collected_at: collected_at,
+      }
+    end
+    let(:simple_location) do
+      described_class.new(latitude: latitude, longitude: longitude)
+    end
+    let(:complete_location) do
+      described_class.new(latitude: latitude, longitude: longitude, collected_at: collected_at)
+    end
+
+    INVALID_TIMESTAMPS = [
+        "2025-04-23T12:12:12-3:00",
+        "2025-04-23T12:12:12-30:00",
+        "2025-04-23T12:12-03:00",
+        "2025-04-23",
+        "20250423",
+        "2024 Mar 03 05:12:41.211 PDT",
+        "Jan 21 18:20:11 +0000 2024",
+        "19/Apr/2023:06:36:15 -0700",
+        "Dec 2, 2023 2:39:58 AM",
+        "Jun 09 2023 15:28:14"
+    ].freeze
+
+    let(:valid_utc_timestamp) { "2025-04-23T12:12:12Z"}
+
+    it "does not accept empty parameters" do
+      expect { described_class.new }.to raise_error ArgumentError
+    end
+
+    it "does not accept just a latitude parameter" do
+      expect { described_class.new(latitude:latitude) }.to raise_error ArgumentError
+    end
+
+    it "does not accept just a longitude parameter" do
+      expect { described_class.new(longitude:longitude) }.to raise_error ArgumentError
+    end
+
+    INVALID_TIMESTAMPS.each do |invalid_ts|
+      it "raises ArgumentError for invalid collected_at: '#{invalid_ts}'" do
+        expect {
+          described_class.new(latitude: latitude, longitude: longitude, collected_at: invalid_ts)
+        }.to raise_error(ArgumentError)
+      end
+    end
+
+    it "accepts a valid UTC timestamp" do
+      utc_timestamp = "2025-04-23T12:12:12Z"
+      location = described_class.new(latitude: latitude, longitude: longitude, collected_at: utc_timestamp)
+    
+      expect(location.to_hash).to eql({
+        latitude: latitude,
+        longitude: longitude,
+        collected_at: utc_timestamp
+      })
+    end
+
+    it "omits nil values" do
+      expect(
+        described_class.new(latitude: latitude, longitude: longitude, collected_at: nil).to_hash
+      ).to eql(simple_format)
+    end
+
+    it "provides #to_hash with the API format (simple)" do
+      expect(simple_location.to_hash).to eql(simple_format)
+    end
+
+    it "provides #to_hash with the API format (complete)" do
+      expect(complete_location.to_hash).to eql(complete_format)
+    end
+  end
+end


### PR DESCRIPTION
## Proposed changes
This PR adds an optional location parameter to the functions used for registering logins and payments.

## Further comments
Requests to the `/transactions` endpoint - i.e. logins and payments - may include a location field (lat, long, time of collection). However, there was no corresponding parameter in the ruby wrapper functions before.

## Checklist

- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works