### PR TITLE
feat: adds Person ID to all endpoints

### DIFF
--- a/lib/incognia_api.rb
+++ b/lib/incognia_api.rb
@@ -7,6 +7,7 @@ require_relative "incognia_api/util"
 require_relative "incognia_api/address"
 require_relative "incognia_api/api"
 require_relative "incognia_api/location"
+require_relative "incognia_api/person_id"
 
 require_relative "incognia_api/resources/api_resource"
 require_relative "incognia_api/resources/signup_assessment"

--- a/lib/incognia_api/api.rb
+++ b/lib/incognia_api/api.rb
@@ -9,10 +9,11 @@ module Incognia
       # business layer: uses the Client.instance to build domain objects
       # raises missing parameters errors
 
-      def register_signup(request_token: nil, address: nil, **opts)
+      def register_signup(request_token: nil, address: nil, person_id: nil, **opts)
         params = { request_token: request_token }.compact
         params.merge!(opts)
         params.merge!(address.to_hash) if address
+        params.merge!(person_id: person_id.to_hash) if person_id
 
         response = connection.request(
           :post,
@@ -23,13 +24,14 @@ module Incognia
         SignupAssessment.from_hash(response.body) if response.success?
       end
 
-      def register_login(account_id:, request_token: nil, location: nil, **opts)
+      def register_login(account_id:, request_token: nil, location: nil, person_id: nil, **opts)
         params = {
           type: :login,
           account_id: account_id,
           request_token: request_token
         }.compact
         params.merge!(location: location.to_hash) if location
+        params.merge!(person_id: person_id.to_hash) if person_id
         params.merge!(opts)
 
         response = connection.request(
@@ -41,11 +43,12 @@ module Incognia
         LoginAssessment.from_hash(response.body) if response.success?
       end
 
-      def register_feedback(event:, occurred_at: nil, expires_at: nil, **ids)
+      def register_feedback(event:, occurred_at: nil, expires_at: nil, person_id: nil, **ids)
         occurred_at = occurred_at.to_datetime.rfc3339 if occurred_at.respond_to? :to_datetime
         expires_at = expires_at.to_datetime.rfc3339 if expires_at.respond_to? :to_datetime
 
         params = { event: event, occurred_at: occurred_at, expires_at: expires_at }.compact
+        params.merge!(person_id: person_id.to_hash) if person_id
         params.merge!(ids)
 
         response = connection.request(
@@ -57,13 +60,14 @@ module Incognia
         response.success?
       end
 
-      def register_payment(account_id:, request_token: nil, location: nil, **opts)
+      def register_payment(account_id:, request_token: nil, location: nil, person_id: nil, **opts)
         params = {
           type: :payment,
           account_id: account_id,
           request_token: request_token
         }.compact
         params.merge!(location: location.to_hash) if location
+        params.merge!(person_id: person_id.to_hash) if person_id
         params.merge!(opts)
 
         response = connection.request(

--- a/lib/incognia_api/person_id.rb
+++ b/lib/incognia_api/person_id.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Incognia
+  class PersonId
+    attr_reader :type, :value
+
+    def initialize(type:, value:)
+      @type  = type
+      @value = value
+    end
+
+    def to_hash
+      { type: type, value: value }
+    end
+  end
+end

--- a/spec/person_id_spec.rb
+++ b/spec/person_id_spec.rb
@@ -1,0 +1,30 @@
+# spec/incognia/person_id_spec.rb
+require "spec_helper"
+
+module Incognia
+  RSpec.describe PersonId do
+    let(:type)  { "cpf" }
+    let(:value) { "12345678901" }
+
+    subject(:person_id) { described_class.new(type: type, value: value) }
+
+    it "requires type and value" do
+      expect { described_class.new }.to raise_error(ArgumentError)
+      expect { described_class.new(type: type) }.to raise_error(ArgumentError)
+      expect { described_class.new(value: value) }.to raise_error(ArgumentError)
+    end
+
+    describe "#to_hash" do
+      it "returns the API format" do
+        expect(person_id.to_hash).to eql(type: type, value: value)
+      end
+    end
+
+    describe "readers" do
+      it "exposes #type and #value" do
+        expect(person_id.type).to  eq(type)
+        expect(person_id.value).to eq(value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Proposed changes

Adds `personID` as an optional parameter to the following methods:

- `register_login`
- `register_signup`
- `register_feedback`
- `register_payment`

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested on the live API endpoint