### PR TITLE
Bump version to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [2.2.0] - 2025-09-16
+
+- Add support for passing an optional person_id parameter to HTTP request helpers
+
 ## [2.1.0] - 2025-05-09
 
 - Add support for passing an optional location parameter to register logins and payments

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    incognia_api (2.1.0)
+    incognia_api (2.2.0)
       faraday (~> 1.10)
       faraday_middleware (~> 1.2)
 

--- a/lib/incognia_api/version.rb
+++ b/lib/incognia_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Incognia
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
## Description

This PR is identical to this (merged) [previous PR](https://github.com/inloco/incognia-ruby/pull/34)

The only purpose of the current PR is to update the version so as to release a new gem with `person_id` support