### PR TITLE
Send previous request latency via X-Incognia-Latency

### DIFF
--- a/lib/incognia_api/client.rb
+++ b/lib/incognia_api/client.rb
@@ -23,12 +23,10 @@ module Incognia
       request_headers = Faraday::Utils::Headers.new.update(headers)
       request_headers[Faraday::Request::Authorization::KEY] ||= "Bearer #{credentials.access_token}"
 
-      if (latency = last_latency_ms)
-        request_headers[LATENCY_HEADER] = latency.to_s
-      end
+      request_headers[LATENCY_HEADER] = last_latency_ms.to_s if last_latency_ms
 
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
-      response = connection.send(method, endpoint, json_data, request_headers)
+      response = connection.send(method, endpoint, json_data, request_headers.compact)
       if response.success?
         store_last_latency(Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start)
       end

--- a/lib/incognia_api/client.rb
+++ b/lib/incognia_api/client.rb
@@ -1,21 +1,39 @@
 require "time"
 require "singleton"
+require "faraday"
 
 module Incognia
   class Client
     include Singleton
+    LATENCY_HEADER = "X-Incognia-Latency".freeze
+
     # TODO:
     # (ok) http/adapter specific code
     # (ok) raises network/authentication errors
     # (ok) handles token refreshing ok
     # future: handles retrying
 
+    def initialize
+      @last_latency_ms = nil
+      @last_latency_mutex = Mutex.new
+    end
+
     def request(method, endpoint = nil, data = nil, headers = {})
       json_data = JSON.generate(data) if data
+      request_headers = Faraday::Utils::Headers.new.update(headers)
+      request_headers[Faraday::Request::Authorization::KEY] ||= "Bearer #{credentials.access_token}"
 
-      connection.send(method, endpoint, json_data, headers) do |r|
-        r.headers[Faraday::Request::Authorization::KEY] ||= "Bearer #{credentials.access_token}"
+      if (latency = last_latency_ms)
+        request_headers[LATENCY_HEADER] = latency.to_s
       end
+
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+      response = connection.send(method, endpoint, json_data, request_headers)
+      if response.success?
+        store_last_latency(Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start)
+      end
+
+      response
     rescue Faraday::ClientError, Faraday::ServerError => e
       raise APIError.new(e.to_s, e.response)
     rescue Faraday::Error => e
@@ -71,6 +89,14 @@ module Incognia
       )
 
       Credentials.from_hash(properties)
+    end
+
+    def last_latency_ms
+      @last_latency_mutex.synchronize { @last_latency_ms }
+    end
+
+    def store_last_latency(latency_ms)
+      @last_latency_mutex.synchronize { @last_latency_ms = latency_ms }
     end
 
   end

--- a/lib/incognia_api/client.rb
+++ b/lib/incognia_api/client.rb
@@ -22,14 +22,11 @@ module Incognia
       json_data = JSON.generate(data) if data
       request_headers = Faraday::Utils::Headers.new.update(headers)
       request_headers[Faraday::Request::Authorization::KEY] ||= "Bearer #{credentials.access_token}"
-
-      request_headers[LATENCY_HEADER] = last_latency_ms.to_s if last_latency_ms
+      request_headers[LATENCY_HEADER] = last_latency_ms&.to_s
 
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
       response = connection.send(method, endpoint, json_data, request_headers.compact)
-      if response.success?
-        store_last_latency(Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start)
-      end
+      store_last_latency(Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start) if response.success?
 
       response
     rescue Faraday::ClientError, Faraday::ServerError => e

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -4,10 +4,13 @@ module Incognia
     let(:sample_json) { JSON.generate(sample_hash) }
     let(:token_fixture) { File.new("spec/fixtures/token.json").read }
     let(:test_endpoint) { "https://api.incognia.com/api/v2/endpoint" }
+    let(:other_test_endpoint) { "https://api.incognia.com/api/v2/other-endpoint" }
 
     subject(:instance) { described_class.instance }
 
     before do
+      Singleton.__init__(described_class)
+
       Incognia.configure(
         client_id: 'client_id',
         client_secret: 'client_secret',
@@ -79,6 +82,94 @@ module Incognia
         expect(stub).to have_been_made.once
       end
 
+      it "does not inject latency header on the first API call" do
+        stub_token_request
+        stub = stub_request(:post, test_endpoint)
+          .with(body: sample_json) { |request| request.headers[described_class::LATENCY_HEADER].to_s.empty? }
+          .to_return(
+            status: 200,
+            body: sample_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        instance.request(:post, 'v2/endpoint', { foo: :bar })
+
+        expect(stub).to have_been_made.once
+      end
+
+      it "injects latency header on the next API call" do
+        stub_token_request
+        stub_request(:post, test_endpoint)
+          .to_return(
+            status: 200,
+            body: sample_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+        stub = stub_request(:post, test_endpoint)
+          .with(body: sample_json) { |request| request.headers[described_class::LATENCY_HEADER]&.match?(/\A\d+\z/) }
+          .to_return(
+            status: 200,
+            body: sample_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        instance.request(:post, 'v2/endpoint', { foo: :bar })
+        instance.request(:post, 'v2/endpoint', { foo: :bar })
+
+        expect(stub).to have_been_made.once
+      end
+
+      it "does not store latency from redirect responses" do
+        stub_token_request
+        stub_request(:post, test_endpoint)
+          .to_return(status: 302, headers: { 'Location' => other_test_endpoint })
+        stub = stub_request(:post, other_test_endpoint)
+          .with(body: sample_json) { |request| request.headers[described_class::LATENCY_HEADER].to_s.empty? }
+          .to_return(
+            status: 200,
+            body: sample_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        response = instance.request(:post, 'v2/endpoint', { foo: :bar })
+        instance.request(:post, 'v2/other-endpoint', { foo: :bar })
+
+        expect(response.status).to eq(302)
+        expect(stub).to have_been_made.once
+      end
+
+      it "overrides a caller-provided latency header with the previous request latency" do
+        stub_token_request
+        allow(Process).to receive(:clock_gettime).and_call_original
+        allow(Process).to receive(:clock_gettime)
+          .with(Process::CLOCK_MONOTONIC, :millisecond)
+          .and_return(1000, 1123, 2000, 2456)
+
+        stub_request(:post, test_endpoint)
+          .to_return(
+            status: 200,
+            body: sample_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+        stub = stub_request(:post, test_endpoint)
+          .with(body: sample_json, headers: { described_class::LATENCY_HEADER => '123' })
+          .to_return(
+            status: 200,
+            body: sample_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        instance.request(:post, 'v2/endpoint', { foo: :bar })
+        instance.request(
+          :post,
+          'v2/endpoint',
+          { foo: :bar },
+          described_class::LATENCY_HEADER => '999'
+        )
+
+        expect(stub).to have_been_made.once
+      end
+
       context "when passing an Authorization header" do
         it  "overrides default header" do
           stub = stub_request(:post, test_endpoint).
@@ -94,6 +185,25 @@ module Incognia
             'v2/endpoint',
             { foo: :bar },
             'Authorization' => 'token'
+          )
+
+          expect(stub).to have_been_made.once
+        end
+
+        it "preserves a lowercase authorization header" do
+          stub = stub_request(:post, test_endpoint)
+            .with(body: sample_json, headers: { 'Authorization' => 'token' })
+            .to_return(
+              status: 200,
+              body: sample_json,
+              headers: { 'Content-Type' => 'application/json' }
+            )
+
+          instance.request(
+            :post,
+            'v2/endpoint',
+            { foo: :bar },
+            'authorization' => 'token'
           )
 
           expect(stub).to have_been_made.once
@@ -145,8 +255,6 @@ module Incognia
     end
 
     describe "#credentials" do
-      before { Singleton.__init__(described_class) }
-
       it "requests an access token from the /token endpoint" do
         stub = stub_token_request
 


### PR DESCRIPTION
## Summary
- track the latency of the last successful API request in the shared client
- send that value in the `X-Incognia-Latency` header on subsequent requests without changing request bodies
- add specs covering first-call omission, cross-request propagation, and overriding a caller-provided latency header
