### PR TITLE
Add keep-alive HTTP configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     incognia_api (3.0.0)
       faraday (~> 2.13)
+      faraday-net_http_persistent (~> 2.3)
 
 GEM
   remote: https://rubygems.org/
@@ -10,6 +11,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     coderay (1.1.3)
+    connection_pool (3.0.2)
     crack (0.4.5)
       rexml
     diff-lcs (1.4.4)
@@ -19,12 +21,17 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    faraday-net_http_persistent (2.3.1)
+      faraday (~> 2.5)
+      net-http-persistent (>= 4.0.4, < 5)
     hashdiff (1.0.1)
     json (2.14.0)
     logger (1.7.0)
     method_source (1.0.0)
     net-http (0.6.0)
       uri
+    net-http-persistent (4.0.8)
+      connection_pool (>= 2.2.4, < 4)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -45,15 +52,15 @@ GEM
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
     timecop (0.9.4)
-    uri (1.0.3)
+    uri (1.1.1)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
-  ruby
   x86_64-darwin-20
+  x86_64-linux-gnu
 
 DEPENDENCIES
   incognia_api!

--- a/README.md
+++ b/README.md
@@ -39,13 +39,23 @@ Before using the API client, you must configure it using credentials obtained
 from the [Incognia dashboard](https://dash.incognia.com/):
 
 ```ruby
-Incognia.configure(client_id: ENV['INCOGNIA_CLIENT_ID'], client_secret: ENV['INCOGNIA_CLIENT_SECRET'])
+Incognia.configure(
+  client_id: ENV['INCOGNIA_CLIENT_ID'],
+  client_secret: ENV['INCOGNIA_CLIENT_SECRET']
+)
+```
 
-# Incognia.configure(client_id: "your-client-id", client_secret: "your-client-secret")
+To reuse HTTP connections between requests, enable `keep_alive`. When enabled,
+`max_connections` sets the maximum number of concurrent persistent
+connections used by the client.
 
-# Keep HTTP connections alive and allow up to 5 concurrent connections.
-# max_connections only applies when keep_alive is enabled.
-# Incognia.configure(client_id: "your-client-id", client_secret: "your-client-secret", keep_alive: true, max_connections: 5)
+```ruby
+Incognia.configure(
+  client_id: ENV['INCOGNIA_CLIENT_ID'],
+  client_secret: ENV['INCOGNIA_CLIENT_SECRET'],
+  keep_alive: true,
+  max_connections: 5
+)
 ```
 
 For sandbox credentials, refer to the [API testing guide](https://developer.incognia.com/).

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ from the [Incognia dashboard](https://dash.incognia.com/):
 Incognia.configure(client_id: ENV['INCOGNIA_CLIENT_ID'], client_secret: ENV['INCOGNIA_CLIENT_SECRET'])
 
 # Incognia.configure(client_id: "your-client-id", client_secret: "your-client-secret")
+
+# Keep HTTP connections alive and allow up to 5 concurrent connections.
+# max_connections only applies when keep_alive is enabled.
+# Incognia.configure(client_id: "your-client-id", client_secret: "your-client-secret", keep_alive: true, max_connections: 5)
 ```
 
 For sandbox credentials, refer to the [API testing guide](https://developer.incognia.com/).

--- a/incognia_api.gemspec
+++ b/incognia_api.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
   spec.add_dependency('faraday', '~> 2.13')
+  spec.add_dependency('faraday-net_http_persistent', '~> 2.3')
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/incognia_api.rb
+++ b/lib/incognia_api.rb
@@ -19,7 +19,7 @@ require_relative "incognia_api/constants/feedback_event"
 
 module Incognia
   def self.configure(**args)
-    config.configure(**args)
+    config.configure(**args).tap { Client.instance.reset! }
   end
 
   def self.config

--- a/lib/incognia_api/client.rb
+++ b/lib/incognia_api/client.rb
@@ -1,5 +1,6 @@
 require "time"
 require "singleton"
+require "faraday/net_http_persistent"
 
 module Incognia
   class Client
@@ -48,10 +49,9 @@ module Incognia
         faraday.response :raise_error
 
         if Incognia.config.keep_alive
-          require 'faraday/net_http_persistent'
-
-          adapter_options = {}
-          adapter_options[:pool_size] = Incognia.config.max_connections if Incognia.config.max_connections
+          adapter_options = {
+            pool_size: Incognia.config.max_connections
+          }.compact
 
           faraday.adapter :net_http_persistent, **adapter_options
         else

--- a/lib/incognia_api/client.rb
+++ b/lib/incognia_api/client.rb
@@ -28,6 +28,12 @@ module Incognia
       @credentials
     end
 
+    def reset!
+      @connection&.close
+      @connection = nil
+      @credentials = nil
+    end
+
     def connection
       return @connection if @connection
 
@@ -41,7 +47,16 @@ module Incognia
         faraday.response :json, content_type: /\bjson$/
         faraday.response :raise_error
 
-        faraday.adapter Faraday.default_adapter
+        if Incognia.config.keep_alive
+          require 'faraday/net_http_persistent'
+
+          adapter_options = {}
+          adapter_options[:pool_size] = Incognia.config.max_connections if Incognia.config.max_connections
+
+          faraday.adapter :net_http_persistent, **adapter_options
+        else
+          faraday.adapter Faraday.default_adapter
+        end
       end
     end
 

--- a/lib/incognia_api/configuration.rb
+++ b/lib/incognia_api/configuration.rb
@@ -4,14 +4,27 @@ module Incognia
   class Configuration
     include Singleton
 
-    attr_accessor :client_id, :client_secret, :host
+    attr_accessor :client_id, :client_secret, :host, :keep_alive, :max_connections
 
-    def configure(client_id:, client_secret:, host: nil)
+    def configure(client_id:, client_secret:, host: nil, keep_alive: false, max_connections: nil)
+      validate_connection_settings!(keep_alive: keep_alive, max_connections: max_connections)
+
       @client_id = client_id
       @client_secret = client_secret
       @host = host || 'https://api.incognia.com/api'
+      @keep_alive = keep_alive
+      @max_connections = max_connections
 
       self
+    end
+
+    private
+
+    def validate_connection_settings!(keep_alive:, max_connections:)
+      return if max_connections.nil?
+
+      raise ArgumentError, 'max_connections requires keep_alive: true' unless keep_alive
+      raise ArgumentError, 'max_connections must be a positive Integer' unless max_connections.is_a?(Integer) && max_connections.positive?
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -144,6 +144,25 @@ module Incognia
       end
     end
 
+    describe "#connection" do
+      before { Singleton.__init__(described_class) }
+
+      it "uses the persistent adapter with the configured max_connections" do
+        Incognia.configure(
+          client_id: 'client_id',
+          client_secret: 'client_secret',
+          host: 'https://api.incognia.com/api',
+          keep_alive: true,
+          max_connections: 5
+        )
+
+        adapter = instance.connection.builder.adapter
+
+        expect(adapter.klass).to eq(Faraday::Adapter::NetHttpPersistent)
+        expect(adapter.instance_variable_get(:@kwargs)).to eq(pool_size: 5)
+      end
+    end
+
     describe "#credentials" do
       before { Singleton.__init__(described_class) }
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -146,6 +146,7 @@ module Incognia
 
     describe "#connection" do
       before { Singleton.__init__(described_class) }
+      after { instance.reset! }
 
       it "uses the persistent adapter with the configured max_connections" do
         Incognia.configure(
@@ -156,10 +157,13 @@ module Incognia
           max_connections: 5
         )
 
-        adapter = instance.connection.builder.adapter
+        allow_any_instance_of(Faraday::RackBuilder).to receive(:adapter).and_call_original
+        expect_any_instance_of(Faraday::RackBuilder).to receive(:adapter)
+          .with(:net_http_persistent, pool_size: 5)
+          .and_call_original
 
-        expect(adapter.klass).to eq(Faraday::Adapter::NetHttpPersistent)
-        expect(adapter.instance_variable_get(:@kwargs)).to eq(pool_size: 5)
+        instance.connection
+
       end
     end
 

--- a/spec/incognia_spec.rb
+++ b/spec/incognia_spec.rb
@@ -87,6 +87,7 @@ module Incognia
 
         it "hits the endpoint with person_id" do
           person_id = PersonId.new(type: "cpf", value: "12345678901")
+          stub_token_request
 
           stub = stub_signup_request.with(
             body: {
@@ -231,6 +232,7 @@ module Incognia
 
         it "hits the endpoint with person_id" do
           person_id = PersonId.new(type: "cpf", value: "12345678901")
+          stub_token_request
 
           stub = stub_login_request.with(
             body: {
@@ -382,6 +384,7 @@ module Incognia
 
         it "hits the endpoint with person_id" do
           person_id = PersonId.new(type: "cpf", value: "12345678901")
+          stub_token_request
 
           stub = stub_payment_request.with(
             body: {

--- a/spec/incognia_spec.rb
+++ b/spec/incognia_spec.rb
@@ -16,6 +16,38 @@ module Incognia
       expect(Configuration.instance.client_secret).to eq(config[:client_secret])
       expect(Configuration.instance.host).to eq(config[:host])
     end
+
+    it 'raises when max_connections is set without keep_alive' do
+      expect {
+        Incognia.configure(
+          client_id: SecureRandom.uuid,
+          client_secret: SecureRandom.uuid,
+          max_connections: 5
+        )
+      }.to raise_error(ArgumentError, 'max_connections requires keep_alive: true')
+    end
+
+    it 'raises when max_connections is not positive' do
+      expect {
+        Incognia.configure(
+          client_id: SecureRandom.uuid,
+          client_secret: SecureRandom.uuid,
+          keep_alive: true,
+          max_connections: 0
+        )
+      }.to raise_error(ArgumentError, 'max_connections must be a positive Integer')
+    end
+
+    it 'raises when max_connections is not an Integer' do
+      expect {
+        Incognia.configure(
+          client_id: SecureRandom.uuid,
+          client_secret: SecureRandom.uuid,
+          keep_alive: true,
+          max_connections: '5'
+        )
+      }.to raise_error(ArgumentError, 'max_connections must be a positive Integer')
+    end
   end
 
   RSpec.describe '.config' do


### PR DESCRIPTION
## Summary
- add `keep_alive` and `max_connections` to Incognia configuration
- use `faraday-net_http_persistent` when keep-alive is enabled and rebuild the cached client on reconfigure
- document the new settings and add spec coverage for persistent adapter configuration
- make the affected request specs explicitly stub token fetches
